### PR TITLE
Bump the dependencies for numpy, meshio. Remove imath pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - cashocs-convert = cashocs._cli:convert
+    - cashocs-extract_mesh = cashocs._cli:extract_mesh
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -23,14 +24,13 @@ requirements:
     - pip
     - python >=3.7
   run:
-    - numpy >=1.21.0
-    - meshio >=4.1.0
-    - python >=3.7
+    - numpy >=1.24.0
+    - meshio >=5.3.0
+    - python >=3.8
     - gmsh >=4.8
     - typing_extensions
     - openssh
     - fenics {{ fenics_version }}
-    - imath <=3.1.6
     - petsc <=3.19
 
 test:


### PR DESCRIPTION
This is done to ensure faster building of the package (higher version pins means less versions to scout for) Additionally, the removal of the imath pin is for testing purposes - have the bugs with imath been fixed?

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
